### PR TITLE
Fixes #13 -- don't call static at import time

### DIFF
--- a/django_better_admin_arrayfield/admin/mixins.py
+++ b/django_better_admin_arrayfield/admin/mixins.py
@@ -1,7 +1,4 @@
-from django.templatetags.static import static
-
-
 class DynamicArrayMixin:
     class Media:
-        js = (static("js/min/django_better_admin_arrayfield.min.js"),)
-        css = {"all": (static("css/min/django_better_admin_arrayfield.min.css"),)}
+        js = ("js/min/django_better_admin_arrayfield.min.js",)
+        css = {"all": ("css/min/django_better_admin_arrayfield.min.css",)}


### PR DESCRIPTION
Calling `static` at import time breaks when you use the manifest
storage because of a missing entry (which happens when you're running
collectstatic).