### PR TITLE
widgets: allow choosing subwidget for DynamicArrayWidget

### DIFF
--- a/django_better_admin_arrayfield/forms/widgets.py
+++ b/django_better_admin_arrayfield/forms/widgets.py
@@ -6,7 +6,7 @@ class DynamicArrayWidget(forms.TextInput):
     template_name = "django_better_admin_arrayfield/forms/widgets/dynamic_array.html"
 
     def __init__(self, *args, **kwargs):
-        self.subwidget_form = kwargs.pop('subwidget_form', forms.TextInput)
+        self.subwidget_form = kwargs.pop("subwidget_form", forms.TextInput)
         super().__init__(*args, **kwargs)
 
     def get_context(self, name, value, attrs):
@@ -41,5 +41,5 @@ class DynamicArrayWidget(forms.TextInput):
 
 class DynamicArrayTextareaWidget(DynamicArrayWidget):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('subwidget_form', forms.Textarea)
+        kwargs.setdefault("subwidget_form", forms.Textarea)
         super().__init__(*args, **kwargs)

--- a/django_better_admin_arrayfield/forms/widgets.py
+++ b/django_better_admin_arrayfield/forms/widgets.py
@@ -5,6 +5,10 @@ class DynamicArrayWidget(forms.TextInput):
 
     template_name = "django_better_admin_arrayfield/forms/widgets/dynamic_array.html"
 
+    def __init__(self, *args, **kwargs):
+        self.subwidget_form = kwargs.pop('subwidget_form', forms.TextInput)
+        super().__init__(*args, **kwargs)
+
     def get_context(self, name, value, attrs):
         context_value = value or [""]
         context = super().get_context(name, context_value, attrs)
@@ -17,7 +21,7 @@ class DynamicArrayWidget(forms.TextInput):
             widget_attrs = final_attrs.copy()
             if id_:
                 widget_attrs["id"] = "{id_}_{index}".format(id_=id_, index=index)
-            widget = forms.TextInput()
+            widget = self.subwidget_form()
             widget.is_required = self.is_required
             subwidgets.append(widget.get_context(name, item, widget_attrs)["widget"])
 
@@ -33,3 +37,9 @@ class DynamicArrayWidget(forms.TextInput):
 
     def format_value(self, value):
         return value or []
+
+
+class DynamicArrayTextareaWidget(DynamicArrayWidget):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('subwidget_form', forms.Textarea)
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
**How about Textarea subwidgets?**

This small commit allows choosing the subwidget for DynamicArrayWidget, and provides DynamicArrayTextareaWidget as drop-in replacement. Some examples follow.

Common case, getting Textarea subwidgets:
```python
from django_better_admin_arrayfield.forms.widgets import DynamicArrayTextareaWidget

MyModelAdmin(models.ModelAdmin, DynamicArrayMixin):
    ...
    formfield_overrides = {
        DynamicArrayField: {'widget': DynamicArrayTextareaWidget},
    }
```

Custom subwidget:
```python
class MyWidget(DynamicArrayWidget):
    def __init__(self, *args, **kwargs):
        kwargs['subwidget_form'] = MyForm
        super().__init__(*args, **kwargs)

MyModelAdmin(models.ModelAdmin, DynamicArrayMixin):
    ...
    formfield_overrides = {
        DynamicArrayField: {'widget': MyWidget},
    }
```

I didn't add tests as there's no "new" functionality.

**Any suggestions for changes are more than welcome** :)