### PR TITLE
Robert8888 patch choices

### DIFF
--- a/django_better_admin_arrayfield/forms/fields.py
+++ b/django_better_admin_arrayfield/forms/fields.py
@@ -19,7 +19,6 @@ class DynamicArrayField(forms.ChoiceField):
         self.default = kwargs.pop("default", None)
         kwargs.setdefault("widget", DynamicArrayWidget)
         super().__init__(**kwargs)
-        
         if hasattr(base_field, 'choices'):
             self.choices = base_field.choices
 

--- a/django_better_admin_arrayfield/forms/fields.py
+++ b/django_better_admin_arrayfield/forms/fields.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from django_better_admin_arrayfield.forms.widgets import DynamicArrayWidget
 
 
-class DynamicArrayField(forms.Field):
+class DynamicArrayField(forms.ChoiceField):
 
     default_error_messages = {
         "item_invalid": _("Item %(nth)s in the array did not validate: "),
@@ -19,6 +19,9 @@ class DynamicArrayField(forms.Field):
         self.default = kwargs.pop("default", None)
         kwargs.setdefault("widget", DynamicArrayWidget)
         super().__init__(**kwargs)
+        
+        if hasattr(base_field, 'choices'):
+            self.choices = base_field.choices
 
     def clean(self, value):
         cleaned_data = []

--- a/django_better_admin_arrayfield/forms/fields.py
+++ b/django_better_admin_arrayfield/forms/fields.py
@@ -19,7 +19,7 @@ class DynamicArrayField(forms.ChoiceField):
         self.default = kwargs.pop("default", None)
         kwargs.setdefault("widget", DynamicArrayWidget)
         super().__init__(**kwargs)
-        if hasattr(base_field, 'choices'):
+        if hasattr(base_field, "choices"):
             self.choices = base_field.choices
 
     def clean(self, value):

--- a/django_better_admin_arrayfield/forms/widgets.py
+++ b/django_better_admin_arrayfield/forms/widgets.py
@@ -10,9 +10,9 @@ class DynamicArrayWidget(forms.TextInput):
         super().__init__(*args, **kwargs)
 
     def create_subwidget(self):
-         if hasattr(self, 'choices') and len(self.choices):
-            return forms.Select(choices = self.choices)
-         else:
+        if hasattr(self, 'choices') and len(self.choices):
+            return forms.Select(choices=self.choices)
+        else:
             return self.subwidget_form()
         
     def get_context(self, name, value, attrs):

--- a/django_better_admin_arrayfield/forms/widgets.py
+++ b/django_better_admin_arrayfield/forms/widgets.py
@@ -10,11 +10,11 @@ class DynamicArrayWidget(forms.TextInput):
         super().__init__(*args, **kwargs)
 
     def create_subwidget(self):
-        if hasattr(self, 'choices') and len(self.choices):
+        if hasattr(self, "choices") and len(self.choices):
             return forms.Select(choices=self.choices)
         else:
             return self.subwidget_form()
-        
+
     def get_context(self, name, value, attrs):
         context_value = value or [""]
         context = super().get_context(name, context_value, attrs)

--- a/django_better_admin_arrayfield/forms/widgets.py
+++ b/django_better_admin_arrayfield/forms/widgets.py
@@ -9,6 +9,12 @@ class DynamicArrayWidget(forms.TextInput):
         self.subwidget_form = kwargs.pop("subwidget_form", forms.TextInput)
         super().__init__(*args, **kwargs)
 
+    def create_subwidget(self):
+         if hasattr(self, 'choices') and len(self.choices):
+            return forms.Select(choices = self.choices)
+         else:
+            return self.subwidget_form()
+        
     def get_context(self, name, value, attrs):
         context_value = value or [""]
         context = super().get_context(name, context_value, attrs)
@@ -21,7 +27,7 @@ class DynamicArrayWidget(forms.TextInput):
             widget_attrs = final_attrs.copy()
             if id_:
                 widget_attrs["id"] = "{id_}_{index}".format(id_=id_, index=index)
-            widget = self.subwidget_form()
+            widget = self.create_subwidget()
             widget.is_required = self.is_required
             subwidgets.append(widget.get_context(name, item, widget_attrs)["widget"])
 


### PR DESCRIPTION
Changing base field for DynamicArrayField adds choices to widget. (even if they are empty). 
[source](https://github.com/django/django/blob/f6018c1e63a04e0c12e2ca759e76e05ccf5e09de/django/forms/fields.py#L782)
It could work without changing base to ChoiceField by just explicitly coping choices field to self.widget.choices like do it base class. But I changed to get validator inheritance as well. 

Now widget checks that it have choices and this choices have not 0 length. If it get choices then it will render subwidget as Select option widget if not then it take TextInput or Textarea or custom. (But this custom have to be onn of select, input or textarea because of js script) 