### PR TITLE
improve custom subwidget section of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ class MyWidget(DynamicArrayWidget):
 class MyModelAdmin(models.ModelAdmin, DynamicArrayMixin):
     ...
     formfield_overrides = {
-        DynamicArrayField: {'widget': MyWidget},
+        ArrayField: {'widget': MyWidget},
     }
 ```
 
@@ -89,7 +89,7 @@ from django_better_admin_arrayfield.forms.widgets import DynamicArrayTextareaWid
 class MyModelAdmin(models.ModelAdmin, DynamicArrayMixin):
     ...
     formfield_overrides = {
-        DynamicArrayField: {'widget': DynamicArrayTextareaWidget},
+        ArrayField: {'widget': DynamicArrayTextareaWidget},
     }
 ```
 


### PR DESCRIPTION
There seems to be an inconsistency in the `custom subwidget` section of the docs.
If `from django_better_admin_arrayfield.models.fields import ArrayField` is used in the model, then in `MyModelAdmin.formfield_overrides` also the same class should be used, otherwise the custom widget will not work